### PR TITLE
Feat/minipay booster

### DIFF
--- a/frontend/src/app/components/NavBar.tsx
+++ b/frontend/src/app/components/NavBar.tsx
@@ -33,8 +33,8 @@ const NavBar = () => {
     <nav className="w-full bg-[#0a192f] border-b border-white/10 sticky top-0 z-[100] h-20 flex items-center">
       <div className="max-w-7xl mx-auto w-full px-6 flex justify-between items-center">
         <Link href="/" className="group">
-          <span className="text-xl md:text-2xl font-black text-white tracking-tighter transition-colors group-hover:text-blue-500">
-            TSAROSAFE<span className="text-blue-500">.</span>
+          <span className="text-lg sm:text-xl md:text-2xl font-black text-white tracking-tighter transition-colors group-hover:text-blue-500">
+            TSAROSAFE<span className="text-blue-500 hidden sm:inline">.</span>
           </span>
         </Link>
         <div className="hidden lg:flex items-center space-x-8">
@@ -44,23 +44,23 @@ const NavBar = () => {
             </Link>
           ))}
         </div>
-        <div className="flex items-center gap-3 md:gap-6">
+        <div className="flex items-center gap-2 sm:gap-3 md:gap-6">
           {mounted && <NetworkStatus />}
           
           {mounted && isMiniPay ? (
             isConnected ? (
-              <div className="border border-yellow-500/30 bg-yellow-500/5 px-3 py-1.5 md:px-5 md:py-2.5 font-mono text-xs md:text-sm text-yellow-500 flex items-center gap-2">
-                <span className="w-2 h-2 bg-yellow-500 rounded-full animate-pulse"></span>
+              <div className="border border-yellow-500/30 bg-yellow-500/5 px-2 py-1 sm:px-3 sm:py-1.5 md:px-5 md:py-2.5 font-mono text-[10px] sm:text-xs md:text-sm text-yellow-500 flex items-center gap-1.5 sm:gap-2">
+                <span className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-yellow-500 rounded-full animate-pulse"></span>
                 <span>{shortAddress}</span>
               </div>
             ) : (
-              <div className="bg-yellow-500/20 text-yellow-500 border border-yellow-500/30 px-3 py-1.5 md:px-6 md:py-2.5 text-[10px] md:text-sm font-black tracking-widest uppercase animate-pulse whitespace-nowrap">
+              <div className="bg-yellow-500/20 text-yellow-500 border border-yellow-500/30 px-2 py-1 sm:px-3 sm:py-1.5 md:px-6 md:py-2.5 text-[10px] md:text-sm font-black tracking-widest uppercase animate-pulse whitespace-nowrap">
                 ⚡ MiniPay <span className="hidden sm:inline">Connected</span>
               </div>
             )
           ) : mounted && isConnected ? (
-            <button onClick={() => disconnect()} className="border border-blue-500 bg-blue-500/5 px-3 py-1.5 md:px-5 md:py-2.5 font-mono text-xs md:text-sm text-blue-400 hover:bg-red-500 hover:text-white hover:border-red-500 transition-all flex items-center gap-2 group">
-              <span className="w-2 h-2 bg-blue-500 rounded-full group-hover:bg-white animate-pulse"></span>
+            <button onClick={() => disconnect()} className="border border-blue-500 bg-blue-500/5 px-2 py-1 sm:px-3 sm:py-1.5 md:px-5 md:py-2.5 font-mono text-[10px] sm:text-xs md:text-sm text-blue-400 hover:bg-red-500 hover:text-white hover:border-red-500 transition-all flex items-center gap-1.5 sm:gap-2 group">
+              <span className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-blue-500 rounded-full group-hover:bg-white animate-pulse"></span>
               <span className="group-hover:hidden">{shortAddress}</span>
               <span className="hidden group-hover:inline text-[10px] uppercase font-black tracking-widest">Disconnect</span>
             </button>

--- a/frontend/src/app/components/NavBar.tsx
+++ b/frontend/src/app/components/NavBar.tsx
@@ -31,9 +31,9 @@ const NavBar = () => {
 
   return (
     <nav className="w-full bg-[#0a192f] border-b border-white/10 sticky top-0 z-[100] h-20 flex items-center">
-      <div className="max-w-7xl mx-auto w-full px-6 flex justify-between items-center">
-        <Link href="/" className="group">
-          <span className="text-lg sm:text-xl md:text-2xl font-black text-white tracking-tighter transition-colors group-hover:text-blue-500">
+      <div className="max-w-7xl mx-auto w-full px-4 sm:px-6 flex justify-between items-center">
+        <Link href="/" className="group flex-shrink-0">
+          <span className="text-base sm:text-xl md:text-2xl font-black text-white tracking-tighter transition-colors group-hover:text-blue-500 whitespace-nowrap">
             TSAROSAFE<span className="text-blue-500 hidden sm:inline">.</span>
           </span>
         </Link>
@@ -44,33 +44,33 @@ const NavBar = () => {
             </Link>
           ))}
         </div>
-        <div className="flex items-center gap-2 sm:gap-3 md:gap-6">
+        <div className="flex items-center gap-2 sm:gap-3 md:gap-6 flex-shrink-0">
           {mounted && <NetworkStatus />}
           
           {mounted && isMiniPay ? (
             isConnected ? (
-              <div className="border border-yellow-500/30 bg-yellow-500/5 px-2 py-1 sm:px-3 sm:py-1.5 md:px-5 md:py-2.5 font-mono text-[10px] sm:text-xs md:text-sm text-yellow-500 flex items-center gap-1.5 sm:gap-2">
-                <span className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-yellow-500 rounded-full animate-pulse"></span>
-                <span>{shortAddress}</span>
+              <div className="flex-shrink-0 border border-yellow-500/30 bg-yellow-500/5 px-2 py-1 sm:px-3 sm:py-1.5 md:px-5 md:py-2.5 font-mono text-[10px] sm:text-xs md:text-sm text-yellow-500 flex items-center gap-1.5 sm:gap-2 whitespace-nowrap">
+                <span className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-yellow-500 rounded-full animate-pulse flex-shrink-0"></span>
+                <span className="whitespace-nowrap">{shortAddress}</span>
               </div>
             ) : (
-              <div className="bg-yellow-500/20 text-yellow-500 border border-yellow-500/30 px-2 py-1 sm:px-3 sm:py-1.5 md:px-6 md:py-2.5 text-[10px] md:text-sm font-black tracking-widest uppercase animate-pulse whitespace-nowrap">
-                ⚡ MiniPay <span className="hidden sm:inline">Connected</span>
+              <div className="flex-shrink-0 bg-yellow-500/20 text-yellow-500 border border-yellow-500/30 px-2 py-1 sm:px-3 sm:py-1.5 md:px-6 md:py-2.5 text-[10px] md:text-sm font-black tracking-widest uppercase animate-pulse whitespace-nowrap">
+                ⚡ MiniPay <span className="hidden md:inline">Connected</span>
               </div>
             )
           ) : mounted && isConnected ? (
-            <button onClick={() => disconnect()} className="border border-blue-500 bg-blue-500/5 px-2 py-1 sm:px-3 sm:py-1.5 md:px-5 md:py-2.5 font-mono text-[10px] sm:text-xs md:text-sm text-blue-400 hover:bg-red-500 hover:text-white hover:border-red-500 transition-all flex items-center gap-1.5 sm:gap-2 group">
-              <span className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-blue-500 rounded-full group-hover:bg-white animate-pulse"></span>
-              <span className="group-hover:hidden">{shortAddress}</span>
-              <span className="hidden group-hover:inline text-[10px] uppercase font-black tracking-widest">Disconnect</span>
+            <button onClick={() => disconnect()} className="flex-shrink-0 border border-blue-500 bg-blue-500/5 px-2 py-1 sm:px-3 sm:py-1.5 md:px-5 md:py-2.5 font-mono text-[10px] sm:text-xs md:text-sm text-blue-400 hover:bg-red-500 hover:text-white hover:border-red-500 transition-all flex items-center gap-1.5 sm:gap-2 group whitespace-nowrap">
+              <span className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-blue-500 rounded-full group-hover:bg-white animate-pulse flex-shrink-0"></span>
+              <span className="group-hover:hidden whitespace-nowrap">{shortAddress}</span>
+              <span className="hidden group-hover:inline text-[10px] uppercase font-black tracking-widest whitespace-nowrap">Disconnect</span>
             </button>
           ) : mounted ? (
-            <button onClick={() => open()} className="bg-white text-[#0a192f] px-4 py-2 md:px-6 md:py-2.5 text-xs md:text-sm font-black tracking-widest uppercase hover:bg-blue-500 hover:text-white transition-all whitespace-nowrap">Connect</button>
+            <button onClick={() => open()} className="flex-shrink-0 bg-white text-[#0a192f] px-4 py-2 md:px-6 md:py-2.5 text-xs md:text-sm font-black tracking-widest uppercase hover:bg-blue-500 hover:text-white transition-all whitespace-nowrap">Connect</button>
           ) : (
-            <div className="bg-white/10 text-white px-4 py-2 md:px-6 md:py-2.5 text-xs md:text-sm font-black tracking-widest uppercase whitespace-nowrap">Loading...</div>
+            <div className="flex-shrink-0 bg-white/10 text-white px-4 py-2 md:px-6 md:py-2.5 text-xs md:text-sm font-black tracking-widest uppercase whitespace-nowrap">Loading...</div>
           )}
           
-          <button onClick={() => setIsMobileMenuOpen(true)} className="lg:hidden flex flex-col justify-center items-end gap-1.5 p-2 group ml-1" aria-label="Open Menu">
+          <button onClick={() => setIsMobileMenuOpen(true)} className="lg:hidden flex flex-col justify-center items-end gap-1.5 p-2 group ml-1 flex-shrink-0" aria-label="Open Menu">
             <div className="w-6 md:w-8 h-0.5 bg-white group-hover:bg-blue-500 transition-colors"></div>
             <div className="w-4 md:w-5 h-0.5 bg-white group-hover:bg-blue-500 transition-colors"></div>
             <div className="w-6 md:w-8 h-0.5 bg-white group-hover:bg-blue-500 transition-colors"></div>

--- a/frontend/src/app/components/NetworkStatus.tsx
+++ b/frontend/src/app/components/NetworkStatus.tsx
@@ -16,15 +16,15 @@ export default function NetworkStatus() {
     const isCelo = chain.id === 42220 || chain.id === 44787;
 
     return (
-        <div className={`flex items-center gap-2 px-3 py-1.5 rounded-full border text-[10px] font-black uppercase tracking-widest transition-all duration-300 ${isBase
+        <div className={`flex-shrink-0 flex items-center gap-1.5 px-2 py-1 sm:px-3 sm:py-1.5 rounded-full border text-[10px] font-black uppercase tracking-widest transition-all duration-300 ${isBase
                 ? "bg-blue-500/10 border-blue-500/20 text-blue-400 shadow-[0_0_15px_rgba(59,130,246,0.1)]"
                 : isCelo
                     ? "bg-green-500/10 border-green-500/20 text-green-400 shadow-[0_0_15px_rgba(34,197,94,0.1)]"
                     : "bg-gray-500/10 border-gray-500/20 text-gray-400"
             }`}>
-            <span className={`w-1.5 h-1.5 rounded-full animate-pulse ${isBase ? "bg-blue-500" : isCelo ? "bg-green-500" : "bg-gray-500"
+            <span className={`w-1.5 h-1.5 rounded-full animate-pulse flex-shrink-0 ${isBase ? "bg-blue-500" : isCelo ? "bg-green-500" : "bg-gray-500"
                 }`}></span>
-            <span className="hidden sm:inline">{chain.name}</span>
+            <span className="hidden md:inline">{chain.name}</span>
         </div>
     );
 }

--- a/frontend/src/app/components/NetworkStatus.tsx
+++ b/frontend/src/app/components/NetworkStatus.tsx
@@ -24,7 +24,7 @@ export default function NetworkStatus() {
             }`}>
             <span className={`w-1.5 h-1.5 rounded-full animate-pulse ${isBase ? "bg-blue-500" : isCelo ? "bg-green-500" : "bg-gray-500"
                 }`}></span>
-            {chain.name}
+            <span className="hidden sm:inline">{chain.name}</span>
         </div>
     );
 }


### PR DESCRIPTION

This PR fixes a responsiveness bug in the main navigation bar on mobile/narrow viewports. Previously, when a wallet was connected, the horizontal layout overflowed the viewport. This caused the right-side elements (like the hamburger menu button) to be clipped off-screen and squished/wrapped the logo text and wallet address into an unreadable state.

## Root Cause
- The logo (`TSAROSAFE.`) and wallet connection elements lacked `flex-shrink-0`, allowing the browser's flexbox layout to compress them to 0 width or wrap them arbitrarily on narrow screens.
- Global container padding on mobile (`px-6` / `24px` on each side) was consuming too much space.
- The network name text (e.g. `CELO`) was rendering on mobile viewports, unnecessarily cluttering the header bar.

## Solutions Implemented

### 1. **Logo Stability & Sizing**
* Added `flex-shrink-0` to the `<Link>` logo element to prevent it from collapsing.
* Added `whitespace-nowrap` to prevent the text `TSAROSAFE.` from breaking onto separate lines.
* Reduced the font size on mobile viewports slightly from `text-lg` to `text-base` for a cleaner, more proportional fit.

### 2. **Mobile Padding & Gaps**
* Reduced the container's outer horizontal padding on mobile from `px-6` (24px) to `px-4` (16px) to maximize screen real estate.
* Used `flex-shrink-0` on the right-side utility wrapper.

### 3. **Wallet Button Cleanup**
* Enforced `whitespace-nowrap` on all wallet details and buttons to prevent address formats (e.g., `0x06Ef...a878`) from wrapping onto two lines.
* Added `flex-shrink-0` to connection statuses (MiniPay and standard connectors).

### 4. **Compact Network Status Badge**
* Modified the visibility query for the chain name text (e.g. `CELO`) in the network badge from `hidden sm:inline` to `hidden md:inline`. On mobile viewports, the badge now cleanly displays as a pulsing color dot, and reveals the full chain text name on tablet/desktop sizes.

## How to Test
1. Connect a wallet (e.g., Celo) on a mobile device or responsive simulator (viewport width ~360px-400px).
2. Verify the logo text is fully visible on the left and the hamburger menu is fully visible on the right without horizontal page overflow or scroll.
3. Verify the wallet address button text remains on a single line and doesn't wrap.
